### PR TITLE
Search complex emojis with multiple equal skin tones by a single one

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,9 @@ Metrics/BlockLength:
     - '*.gemspec'
     - 'spec/**/*_spec.rb'
 
+Metrics/AbcSize:
+  Max: 18
+
 Lint/MissingSuper:
   Enabled: false
 

--- a/lib/emoji_datasource.rb
+++ b/lib/emoji_datasource.rb
@@ -75,15 +75,6 @@ module EmojiDatasource
       emoji.variations.each do |emoji_variant|
         emoji_variant.short_names.each do |short_name|
           result[short_name] = emoji_variant
-
-          # Allow to find complex emojis with multiple equal skin tone codes by single skin tone
-          # For some emojis (like :women_holding_hands:) there are already special single skin tone emojis exists.
-          # but for others (like :people_holding_hands:) there are no such versions, only versions with separate tones.
-          # However, some implementations in the wild (e.g. Slack and EmojiMart) understand short codes
-          # containing only single skin tone (e.g. `:people_holding_hands::skin-tone-N:`)
-          if short_name =~ /skin-tone-(\d)(?:::skin-tone-\1)+/ # repeated skin tone, e.g. `skin-tone-2::skin-tone-2`
-            result["#{emoji.short_name}::skin-tone-#{$1}"] ||= emoji_variant
-          end
         end
       end
     end

--- a/spec/emoji_datasource_spec.rb
+++ b/spec/emoji_datasource_spec.rb
@@ -70,11 +70,6 @@ RSpec.describe EmojiDatasource do
       expect(described_class.find_by_short_name(':people_holding_hands::skin-tone-2:')).to \
         eq(described_class.find_by_short_name(':people_holding_hands::skin-tone-2::skin-tone-2:'))
     end
-
-    it 'doesn\'t override existing short skin toned emoji' do
-      expect(described_class.find_by_short_name(':women_holding_hands::skin-tone-2:')).not_to \
-        eq(described_class.find_by_short_name(':women_holding_hands::skin-tone-2::skin-tone-2:'))
-    end
   end
 
   describe '.find_by_unified' do

--- a/spec/emoji_datasource_spec.rb
+++ b/spec/emoji_datasource_spec.rb
@@ -65,6 +65,16 @@ RSpec.describe EmojiDatasource do
     it 'does not find emoji when skin tone variants used for an emoji that doesn\'t support it' do
       expect(described_class.find_by_short_name(':hamsa::skin-tone-2:')).to be_nil
     end
+
+    it 'finds complex emoji with multiple equal skin tones by single skin tone' do
+      expect(described_class.find_by_short_name(':people_holding_hands::skin-tone-2:')).to \
+        eq(described_class.find_by_short_name(':people_holding_hands::skin-tone-2::skin-tone-2:'))
+    end
+
+    it 'doesn\'t override existing short skin toned emoji' do
+      expect(described_class.find_by_short_name(':women_holding_hands::skin-tone-2:')).not_to \
+        eq(described_class.find_by_short_name(':women_holding_hands::skin-tone-2::skin-tone-2:'))
+    end
   end
 
   describe '.find_by_unified' do


### PR DESCRIPTION
Hello again! Here I want to propose one more usability enhancement for better compatibility with real world usage of emoji short codes.

**TL;DR**: Allows to find emoji 🧑🏽‍🤝‍🧑🏽 by shortened code `:people_holding_hands::skin-tone-3:` in addition to current `:people_holding_hands::skin-tone-3::skin-tone-3:` to improve compatibility.

**The problem**

Existing apps (e.g. Slack) and libraries (e.g. [EmojiMart](https://github.com/missive/emoji-mart) emoji picker) recognizes shorthand codes for **complex emojis that have multiple skin tone variation _axes_** for the case when _all_ of these axes has the same skin tone selected.

Example of such emoji is [People holding hands 🧑‍🤝‍🧑](https://emojipedia.org/people-holding-hands/) that can have dozens of skin tones variations where two people can have the same or different skin tones (e.g. 🧑🏽‍🤝‍🧑🏽 or 🧑🏻‍🤝‍🧑🏿).

To confuse things more, some other (older) emojis (like [Women holding hands 👭](https://emojipedia.org/women-holding-hands/) actually have special (separate) variants for the case when both people on the emoji has the same skin tone (also for historical reasons I believe). E.g. check codepoints for [Women Holding Hands: Light Skin Tone 👭🏻](https://emojipedia.org/women-holding-hands-light-skin-tone/) and [Women Holding Hands: Light Skin Tone, Dark Skin Tone 👩🏻‍🤝‍👩🏿](https://emojipedia.org/women-holding-hands-light-skin-tone-dark-skin-tone/).

You can check the difference yourself in the [emoji data set](https://raw.githubusercontent.com/iamcal/emoji-data/v14.0.0/emoji_pretty.json) (look for `skin_variations` field for `people_holding_hands` and `women_holding_hands` and you will see it)

In current emoji-datasource implementation, former light skin tone emoji can be found only by `:people_holding_hands::skin-tone-2::skin-tone-2:` while latter – only by `:two_women_holding_hands::skin-tone-2:`.

However, Slack correctly understands short codes for both `:people_holding_hands::skin-tone-2:` and `:two_women_holding_hands::skin-tone-2:`. EmojiMart also sends the same codes if skin tone is set (it doesn't support that multidimensional skin tone variatons at the time of writing) and they can't be recognized yet.

<details>
<summary>Full list of complex emoji with multiple skin tone dimensions and without short versions for the case when all skin tones are equal</summary>

```
man-heart-man
man-kiss-man
people_holding_hands
woman-heart-man
woman-kiss-man
woman-kiss-woman
```
</details>

**The solution**

Add `:people_holding_hands::skin-tone-2:` key to short code search hash map, pointing to the `:people_holding_hands::skin-tone-2::skin-tone-2:` emoji.